### PR TITLE
Use an alias to boost::variant instead of wrapping the type

### DIFF
--- a/include/resilient/detail/variant_boost.hpp
+++ b/include/resilient/detail/variant_boost.hpp
@@ -35,28 +35,9 @@ public:
     }
 };
 
-template<typename Variant>
-struct as_boost_variant
-{
-    using type = same_const_ref_as_t<Variant, typename std::decay_t<Variant>::ImplVariant>;
-};
-
-template<typename Variant>
-using as_boost_variant_t = typename as_boost_variant<Variant>::type;
-
-// Allow to access the Failable as if it was a varian, so that all the variant functions can be used
-template<typename Variant>
-as_boost_variant_t<Variant> get_boost_variant(Variant&& v)
-{
-    return move_if_not_lvalue<Variant>(v.d_data);
-}
-
-template<typename Q>
-using if_is_default_constructible = std::enable_if_t<std::is_default_constructible<Q>::value>;
-
 
 template<typename ...Types>
-class Variant;// Forward declare so that we can define is_variant before the implementation
+using Variant = boost::variant<Types...>;
 
 
 template<typename T>
@@ -66,56 +47,6 @@ struct is_variant<Variant<Types...>> : std::true_type {};
 
 template<typename Q>
 using if_is_variant = std::enable_if_t<is_variant<std::decay_t<Q>>::value, void*>;
-
-template<typename Q>
-using if_is_not_variant = std::enable_if_t<not is_variant<std::decay_t<Q>>::value, void*>;
-
-template<typename ...Types>
-class Variant
-{
-// wrap boost variant, providing a more c++17 similar interface.
-public:
-    template<typename U = argpack_element_t<0, Types...>,
-             typename = if_is_default_constructible<U>>
-    Variant() {} // Use a template parameter U so that the evaluation is postponed
-                 // until instantiation
-
-    template<typename Other, if_is_variant<Other> = nullptr>
-    Variant(Other&& other)
-    : d_data(move_if_not_lvalue<Other>(other.d_data)) {}
-
-    template<typename Other, if_is_not_variant<Other> = nullptr>
-    Variant(Other&& other)
-    : d_data(std::forward<Other>(other)) {}
-
-    template<typename Other, if_is_variant<Other> = nullptr>
-    Variant& operator=(Other&& other)
-    {
-        d_data = move_if_not_lvalue<Other>(other.d_data);
-        return *this;
-    }
-
-    template<typename Other, if_is_not_variant<Other> = nullptr>
-    Variant& operator=(Other&& other)
-    {
-        d_data = std::forward<Other>(other);
-        return *this;
-    }
-
-private:
-    using ImplVariant = boost::variant<Types...>;
-    ImplVariant d_data;
-
-    template<typename ...OtherTypes>
-    friend class Variant;
-
-    template<typename Variant>
-    friend struct as_boost_variant;
-
-    template<typename Variant>
-    friend as_boost_variant_t<Variant> get_boost_variant(Variant&& f);
-
-};
 
 // Visitor which forwards the value based on the ref-ness of the owning variant
 template<typename Visitor, typename Variant>
@@ -136,7 +67,7 @@ struct RvalueForwardingVisitor
 template<typename T, typename Variant, if_is_variant<Variant> = nullptr>
 bool holds_alternative(Variant&& variant) // TODO make it fail to compile if the variant can not hold T
 {
-    return boost::apply_visitor(IsType<T>(), get_boost_variant(std::forward<Variant>(variant)));
+    return boost::apply_visitor(IsType<T>(), std::forward<Variant>(variant));
 }
 
 #if BOOST_STRICT_GET_NO_RVAL_SUPPORT
@@ -155,7 +86,7 @@ auto get(Variant&& variant) -> same_const_ref_as_t<Variant, T>
     // Put boost::strict_get in the scope and use the unscoped call so that the overload we defined can be found
     using boost::strict_get;
     using resilient::detail::strict_get;
-    return strict_get<T>(get_boost_variant(std::forward<Variant>(variant)));
+    return strict_get<T>(std::forward<Variant>(variant));
 }
 
 template<typename Visitor, typename Variant, if_is_variant<Variant> = nullptr>
@@ -164,7 +95,7 @@ decltype(auto) visit(Visitor&& visitor, Variant&& variant)
     // Boost does not support r-value visitors or variants in apply_visitor.
     // We wrap the visitor so that we do the forwarding.
     RvalueForwardingVisitor<Visitor, Variant> wrapper{visitor};
-    return boost::apply_visitor(wrapper, get_boost_variant(variant));
+    return boost::apply_visitor(wrapper, variant);
 }
 
 }


### PR DESCRIPTION
This fails to compile. Yet have to figure why and how to fix.

```
In file included from /usr/include/boost/variant/variant.hpp:2412:0,
                 from /usr/include/boost/variant.hpp:17,
                 from resilient/include/resilient/detail/variant_boost2.hpp:7,
                 from resilient/include/resilient/common/variant.hpp:14,
                 from resilient/include/resilient/task/failable.hpp:6,
                 from resilient/include/resilient/task/task.hpp:28,
                 from resilient/test/task.t.cpp:1:
/usr/include/boost/variant/detail/variant_io.hpp: In instantiation of ‘void boost::detail::variant::printer<OStream>::operator()(const T&) const [with T = res
ilient::NoFailure; OStream = std::basic_ostream<char>]’:
/usr/include/boost/variant/variant.hpp:978:24:   required from ‘boost::detail::variant::invoke_visitor<Visitor>::result_type boost::detail::variant::invoke_vi
sitor<Visitor>::internal_visit(T&, int) [with T = const resilient::NoFailure; Visitor = boost::detail::variant::printer<std::basic_ostream<char> >; boost::det
ail::variant::invoke_visitor<Visitor>::result_type = void]’
/usr/include/boost/variant/detail/visitation_impl.hpp:114:9:   required from ‘typename Visitor::result_type boost::detail::variant::visitation_impl_invoke_imp
l(int, Visitor&, VoidPtrCV, T*, mpl_::true_) [with Visitor = boost::detail::variant::invoke_visitor<boost::detail::variant::printer<std::basic_ostream<char> >
 >; VoidPtrCV = const void*; T = resilient::NoFailure; typename Visitor::result_type = void; mpl_::true_ = mpl_::bool_<true>]’
/usr/include/boost/variant/detail/visitation_impl.hpp:154:41:   required from ‘typename Visitor::result_type boost::detail::variant::visitation_impl_invoke(in
t, Visitor&, VoidPtrCV, T*, NoBackupFlag, int) [with Visitor = boost::detail::variant::invoke_visitor<boost::detail::variant::printer<std::basic_ostream<char>
 > >; VoidPtrCV = const void*; T = resilient::NoFailure; NoBackupFlag = boost::variant<resilient::NoFailure, {anonymous}::FailureMock>::has_fallback_type_; ty
pename Visitor::result_type = void]’
/usr/include/boost/variant/detail/visitation_impl.hpp:238:5:   required from ‘typename Visitor::result_type boost::detail::variant::visitation_impl(int, int, 
Visitor&, VoidPtrCV, mpl_::false_, NoBackupFlag, Which*, step0*) [with Which = mpl_::int_<0>; step0 = boost::detail::variant::visitation_impl_step<boost::mpl:
:l_iter<boost::mpl::l_item<mpl_::long_<2l>, resilient::NoFailure, boost::mpl::l_item<mpl_::long_<1l>, {anonymous}::FailureMock, boost::mpl::l_end> > >, boost:
:mpl::l_iter<boost::mpl::l_end> >; Visitor = boost::detail::variant::invoke_visitor<boost::detail::variant::printer<std::basic_ostream<char> > >; VoidPtrCV = const void*; NoBackupFlag = boost::variant<resilient::NoFailure, {anonymous}::FailureMock>::has_fallback_type_; typename Visitor::result_type = void; mpl_::false_ = mpl_::bool_<false>]’
/usr/include/boost/variant/variant.hpp:2318:48:   required from ‘static typename Visitor::result_type boost::variant<T0, TN>::internal_apply_visitor_impl(int, int, Visitor&, VoidPtrCV) [with Visitor = boost::detail::variant::invoke_visitor<boost::detail::variant::printer<std::basic_ostream<char> > >; VoidPtrCV = const void*; T0_ = resilient::NoFailure; TN = {{anonymous}::FailureMock}; typename Visitor::result_type = void]’
/usr/include/boost/variant/variant.hpp:2343:43:   required from ‘typename Visitor::result_type boost::variant<T0, TN>::internal_apply_visitor(Visitor&) const [with Visitor = boost::detail::variant::invoke_visitor<boost::detail::variant::printer<std::basic_ostream<char> > >; T0_ = resilient::NoFailure; TN = {{anonymous}::FailureMock}; typename Visitor::result_type = void]’
/usr/include/boost/variant/variant.hpp:2367:52:   required from ‘typename Visitor::result_type boost::variant<T0, TN>::apply_visitor(Visitor&) const [with Visitor = boost::detail::variant::printer<std::basic_ostream<char> >; T0_ = resilient::NoFailure; TN = {{anonymous}::FailureMock}; typename Visitor::result_type = void]’
/usr/include/boost/variant/detail/variant_io.hpp:88:5:   required from ‘std::basic_ostream<_CharT, _Traits>& boost::operator<<(std::basic_ostream<_CharT, _Tra
its>&, const boost::variant<U0, UN ...>&) [with E = char; T = std::char_traits<char>; U0 = resilient::NoFailure; UN = {{anonymous}::FailureMock}]’
/usr/include/gtest/gtest-printers.h:245:7:   required from ‘void testing_internal::DefaultPrintNonContainerTo(const T&, std::ostream*) [with T = boost::variant<resilient::NoFailure, {anonymous}::FailureMock>; std::ostream = std::basic_ostream<char>]’
/usr/include/gtest/gtest-printers.h:338:49:   required from ‘void testing::internal::DefaultPrintTo(testing::internal::IsNotContainer, testing::internal::false_type, const T&, std::ostream*) [with T = boost::variant<resilient::NoFailure, {anonymous}::FailureMock>; testing::internal::IsNotContainer = char; testing::internal::false_type = testing::internal::bool_constant<false>; std::ostream = std::basic_ostream<char>]’
/usr/include/gtest/gtest-printers.h:376:17:   required from ‘void testing::internal::PrintTo(const T&, std::ostream*) [with T = boost::variant<resilient::NoFailure, {anonymous}::FailureMock>; std::ostream = std::basic_ostream<char>]’
/usr/include/gtest/gtest-printers.h:600:12:   required from ‘static void testing::internal::UniversalPrinter<T>::Print(const T&, std::ostream*) [with T = boost::variant<resilient::NoFailure, {anonymous}::FailureMock>; std::ostream = std::basic_ostream<char>]’
/usr/include/gmock/gmock-spec-builders.h:1339:31:   required from ‘void testing::internal::ActionResultHolder<T>::PrintAsActionResult(std::ostream*) const [with T = boost::variant<resilient::NoFailure, {anonymous}::FailureMock>; std::ostream = std::basic_ostream<char>]’
/media/francesco/A6528DA1528D76B9/Programmazione/projects/resilient/test/task.t.cpp:80:1:   required from here
/usr/include/boost/variant/detail/variant_io.hpp:64:14: error: no match for ‘operator<<’ (operand types are ‘std::basic_ostream<char>’ and ‘const resilient::NoFailure’)
         out_ << operand;
         ~~~~~^~~~~~~~~~

```